### PR TITLE
Feat translate bo content to en

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Test with pytest
       env:
         GITHUB_TOKEN: "dummy value"
+        ANTHROPIC_API_KEY: "dummy value"
       run: PYTHONPATH=src pytest
 
     - name: Test Coverage

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,4 +37,5 @@ jobs:
     - name: Test Coverage
       env:
           GITHUB_TOKEN: "dummy value"
+          ANTHROPIC_API_KEY: "dummy value"
       run: PYTHONPATH=src pytest --cov openpecha

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
   "python-docx >= 1.1.2",
   "bo-sent-tokenizer @ git+https://github.com/OpenPecha/bo_sent_tokenizer.git",
   "fast_antx @ git+https://github.com/OpenPecha/fast-antx.git",
-  "pecha_org_tools @ git+https://github.com/OpenPecha/pecha_org_tools.git"
+  "pecha_org_tools @ git+https://github.com/OpenPecha/pecha_org_tools.git",
+  "anthropic == 0.40.0"
 
 ]
 

--- a/src/openpecha/pecha/serializers/commentary.py
+++ b/src/openpecha/pecha/serializers/commentary.py
@@ -347,7 +347,7 @@ class CommentarySerializer:
         self.source_book[0]["content"] = en_content
 
         serialized_json = {
-            "source": {"categories": self.source_category, "book": self.source_book},
-            "target": {"categories": self.target_category, "book": self.target_book},
+            "source": {"categories": self.source_category, "books": self.source_book},
+            "target": {"categories": self.target_category, "books": self.target_book},
         }
         return serialized_json

--- a/tests/pecha/serializers/pecha_db/commentary/data/commentary_serialized.json
+++ b/tests/pecha/serializers/pecha_db/commentary/data/commentary_serialized.json
@@ -34,7 +34,20 @@
         "versionSource": "https://library.bdrc.io/show/bdr:WA1KG12670?tabs=bdr:MW3JT13747,bdr:W3JT13747",
         "direction": "ltr",
         "completestatus": "done",
-        "content": {}
+        "content": {
+          "Commentary on the Structure of the Sutra": {
+            "data": [],
+            "The Unbroken Lineage of Buddha's Teachings": {
+              "data": []
+            }
+          },
+          "Explanation of the Meaning of Words": {
+            "data": [],
+            "The Unbroken Lineage of Buddha's Teachings": {
+              "data": []
+            }
+          }
+        }
       }
     ]
   },

--- a/tests/pecha/serializers/pecha_db/commentary/data/commentary_serialized.json
+++ b/tests/pecha/serializers/pecha_db/commentary/data/commentary_serialized.json
@@ -27,7 +27,7 @@
         "link": "Commentary"
       }
     ],
-    "book": [
+    "books": [
       {
         "title": "Vajra Cutter",
         "language": "en",
@@ -79,7 +79,7 @@
         "link": "Commentary"
       }
     ],
-    "book": [
+    "books": [
       {
         "title": "རྡོ་རྗེ་གཅོད་པ།",
         "language": "bo",

--- a/tests/pecha/serializers/pecha_db/commentary/test_commentary_serializer.py
+++ b/tests/pecha/serializers/pecha_db/commentary/test_commentary_serializer.py
@@ -12,7 +12,9 @@ def test_commentary_serializer():
     # Patch the `get_category` method in `CategoryExtractor` to return a custom value
     with patch(
         "pecha_org_tools.extract.CategoryExtractor.get_category"
-    ) as mock_get_category:
+    ) as mock_get_category, patch(
+        "openpecha.pecha.serializers.commentary.CommentarySerializer.get_en_content_translation"
+    ) as mock_get_en_content:
         mock_get_category.return_value = {
             "bo": [
                 {"name": "སངས་རྒྱས་ཀྱི་བཀའ།", "heDesc": "", "heShortDesc": ""},
@@ -26,6 +28,16 @@ def test_commentary_serializer():
                 {"name": "Commentaries", "enDesc": "", "enShortDesc": ""},
                 {"name": "Vajra Cutter", "enDesc": "", "enShortDesc": ""},
             ],
+        }
+        mock_get_en_content.return_value = {
+            "Commentary on the Structure of the Sutra": {
+                "data": [],
+                "The Unbroken Lineage of Buddha's Teachings": {"data": []},
+            },
+            "Explanation of the Meaning of Words": {
+                "data": [],
+                "The Unbroken Lineage of Buddha's Teachings": {"data": []},
+            },
         }
 
         serializer = CommentarySerializer()


### PR DESCRIPTION
Get the literal english translation of the bo content complex structure
```python       
 Eg: Input:> bo_content = {
                    "བོད་": {"data": ["བོད་ནི་འཛམ་གླིང་གི་ས་ཆ་མཐོ་ཤོས་དང་ཆེས་ངོམས་ཅན་གྱི་ས་ཁུལ་ཞིག་ཡིན།"], "བོད་མི་": {"གཞི་གྲངས་": []},
                    "སྨོན་ལམ་རིག་ནུས།་": {"data": [],"མཉེན་ཆས་སྒྱུར་ཞིབ་": {"data": []}}
                    }

            Output:> en_content = {
                "Tibet":{"data":[], "Tibetans": {"data":[]},
                "Monlam AI": {"data":[],"Machine Translation": {"data":[]}}
            }
```
        1. The keys are translated, except for the "data" key which is same.
        2. The values of the "data" key in output should be empty list.