### PR TITLE
Fix/translation parser serializer

### DIFF
--- a/src/openpecha/alignment/serializers/__init__.py
+++ b/src/openpecha/alignment/serializers/__init__.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Dict
 
+from openpecha.pecha import Pecha
+
 
 class BaseAlignmentSerializer(ABC):
     @property
@@ -11,7 +13,7 @@ class BaseAlignmentSerializer(ABC):
     @abstractmethod
     def serialize(
         self,
-        root_opf: Path,
-        translation_opf: Path,
+        root_pecha: Pecha,
+        translation_pecha: Pecha,
     ) -> Dict:
         pass

--- a/src/openpecha/alignment/serializers/translation.py
+++ b/src/openpecha/alignment/serializers/translation.py
@@ -10,12 +10,13 @@ from openpecha.utils import chunk_strings, get_text_direction_with_lang
 
 
 class TextTranslationSerializer(BaseAlignmentSerializer):
-    def set_pecha_category(self, category: str):
+    def get_pecha_category(self, pecha: Pecha):
         """
         Set pecha category both in english and tibetan in the JSON output.
         """
+        pecha_title = self.get_pecha_title(pecha)
         category_extractor = CategoryExtractor()
-        categories = category_extractor.get_category(category)
+        categories = category_extractor.get_category(pecha_title)
         return categories["bo"], categories["en"]
 
     def extract_metadata(self, pecha: Pecha):
@@ -49,7 +50,7 @@ class TextTranslationSerializer(BaseAlignmentSerializer):
             "" if str(ann) == "\n" else str(ann).replace("\n", "<br>") for ann in layer
         ]
 
-    def set_root_content(self, pecha: Pecha, root_basename: str, root_layername: str):
+    def get_root_content(self, pecha: Pecha, root_basename: str, root_layername: str):
         """
         Processes:
         1. Get the first txt file from root and translation opf
@@ -62,7 +63,7 @@ class TextTranslationSerializer(BaseAlignmentSerializer):
         segments = self.get_texts_from_layer(segment_layer)
         return chunk_strings(segments)
 
-    def set_translation_content(
+    def get_translation_content(
         self,
         pecha: Pecha,
         translation_basename: str,
@@ -213,8 +214,7 @@ class TextTranslationSerializer(BaseAlignmentSerializer):
         translation_json["books"].append(self.extract_metadata(translation_pecha))
 
         # Get pecha category from pecha_org_tools package and set to JSON
-        pecha_title = self.get_pecha_title(root_pecha)
-        bo_category, en_category = self.set_pecha_category(pecha_title)
+        bo_category, en_category = self.get_pecha_category(root_pecha)
 
         root_json["categories"] = bo_category
         translation_json["categories"] = en_category
@@ -225,12 +225,12 @@ class TextTranslationSerializer(BaseAlignmentSerializer):
         )
 
         # Set the content for source and target and set it to JSON
-        root_json["books"][0]["content"] = self.set_root_content(
+        root_json["books"][0]["content"] = self.get_root_content(
             root_pecha,
             alignment_layer["root_basename"],
             alignment_layer["root_layername"],
         )
-        translation_json["books"][0]["content"] = self.set_translation_content(
+        translation_json["books"][0]["content"] = self.get_translation_content(
             translation_pecha,
             alignment_layer["translation_basename"],
             alignment_layer["translation_layername"],

--- a/src/openpecha/alignment/serializers/translation.py
+++ b/src/openpecha/alignment/serializers/translation.py
@@ -233,9 +233,9 @@ class TextTranslationSerializer(BaseAlignmentSerializer):
         }
 
         # Set the content for source and target and set it to JSON
-        json_output = {
+        serialized_json = {
             "source": translation_json,
             "target": root_json,
         }
 
-        return json_output
+        return serialized_json

--- a/src/openpecha/alignment/serializers/translation.py
+++ b/src/openpecha/alignment/serializers/translation.py
@@ -206,31 +206,33 @@ class TextTranslationSerializer(BaseAlignmentSerializer):
         # Get pecha category from pecha_org_tools package and set to JSON
         bo_category, en_category = self.get_pecha_category(root_pecha)
 
-        root_json: Dict[str, List] = {
-            "categories": bo_category,
-            "books": [self.get_metadata_for_pecha_org(root_pecha)],
-        }
-        translation_json: Dict[str, List] = {
-            "categories": en_category,
-            "books": [self.get_metadata_for_pecha_org(translation_pecha)],
-        }
-
         # Get the root and translation layer to serialize the layer(STAM) to JSON
         alignment_data = self.get_root_and_translation_layer(
             root_pecha, translation_pecha, is_pecha_display
         )
 
-        # Set the content for source and target and set it to JSON
-        root_json["books"][0]["content"] = self.get_root_content(
-            root_pecha,
-            alignment_data,
-        )
-        translation_json["books"][0]["content"] = self.get_translation_content(
-            translation_pecha,
-            alignment_data,
-            is_pecha_display,
-        )
+        root_json: Dict[str, List] = {
+            "categories": bo_category,
+            "books": [
+                {
+                    **self.get_metadata_for_pecha_org(root_pecha),
+                    "content": self.get_root_content(root_pecha, alignment_data),
+                }
+            ],
+        }
+        translation_json: Dict[str, List] = {
+            "categories": en_category,
+            "books": [
+                {
+                    **self.get_metadata_for_pecha_org(translation_pecha),
+                    "content": self.get_translation_content(
+                        translation_pecha, alignment_data, is_pecha_display
+                    ),
+                }
+            ],
+        }
 
+        # Set the content for source and target and set it to JSON
         json_output = {
             "source": translation_json,
             "target": root_json,

--- a/src/openpecha/alignment/serializers/translation.py
+++ b/src/openpecha/alignment/serializers/translation.py
@@ -19,7 +19,7 @@ class TextTranslationSerializer(BaseAlignmentSerializer):
         categories = category_extractor.get_category(pecha_title)
         return categories["bo"], categories["en"]
 
-    def extract_metadata(self, pecha: Pecha):
+    def get_metadata_for_pecha_org(self, pecha: Pecha):
         """
         Extract required metadata from opf
         """
@@ -200,24 +200,18 @@ class TextTranslationSerializer(BaseAlignmentSerializer):
         translation_pecha: Pecha,
         is_pecha_display: bool = True,
     ) -> Dict:
-        root_json: Dict[str, List] = {
-            "categories": [],
-            "books": [],
-        }
-        translation_json: Dict[str, List] = {
-            "categories": [],
-            "books": [],
-        }
-
-        # Extract metadata from opf and set to JSON
-        root_json["books"].append(self.extract_metadata(root_pecha))
-        translation_json["books"].append(self.extract_metadata(translation_pecha))
 
         # Get pecha category from pecha_org_tools package and set to JSON
         bo_category, en_category = self.get_pecha_category(root_pecha)
 
-        root_json["categories"] = bo_category
-        translation_json["categories"] = en_category
+        root_json: Dict[str, List] = {
+            "categories": bo_category,
+            "books": [self.get_metadata_for_pecha_org(root_pecha)],
+        }
+        translation_json: Dict[str, List] = {
+            "categories": en_category,
+            "books": [self.get_metadata_for_pecha_org(translation_pecha)],
+        }
 
         # Get the root and translation layer to serialize the layer(STAM) to JSON
         alignment_layer = self.get_root_and_translation_layer(

--- a/src/openpecha/pecha/parsers/__init__.py
+++ b/src/openpecha/pecha/parsers/__init__.py
@@ -15,7 +15,7 @@ class BaseParser(ABC):
     def parse(
         self,
         input: Any,
-        metadata: Union[Dict, Path],
+        metadata: Dict,
         output_path: Path = PECHAS_PATH,
     ):
         pass

--- a/src/openpecha/pecha/parsers/google_doc/translation.py
+++ b/src/openpecha/pecha/parsers/google_doc/translation.py
@@ -135,7 +135,7 @@ class GoogleDocTranslationParser(BaseParser):
         input: Path,
         metadata: Dict,
         output_path: Path = PECHAS_PATH,
-    ):
+    ) -> "Pecha":
         """
         Inputs:
             input: Docx file path
@@ -152,8 +152,8 @@ class GoogleDocTranslationParser(BaseParser):
 
         """
         anns, base = self.extract_root_idx(input, metadata)
-        pecha, layer_path = self.create_pecha(anns, base, metadata, output_path)
-        return pecha, layer_path
+        pecha, _ = self.create_pecha(anns, base, metadata, output_path)
+        return pecha
 
     def create_pecha(
         self, anns: List[Dict], base: str, metadata: Dict, output_path: Path

--- a/src/openpecha/pecha/parsers/google_doc/translation.py
+++ b/src/openpecha/pecha/parsers/google_doc/translation.py
@@ -11,7 +11,6 @@ from openpecha.pecha import Pecha
 from openpecha.pecha.layer import LayerEnum
 from openpecha.pecha.metadata import InitialCreationType, Language, PechaMetaData
 from openpecha.pecha.parsers import BaseParser
-from openpecha.pecha.parsers.parser_utils import extract_metadata_from_xlsx
 
 
 class GoogleDocTranslationParser(BaseParser):
@@ -152,12 +151,6 @@ class GoogleDocTranslationParser(BaseParser):
             - Create OPF
 
         """
-        if isinstance(metadata, Path):
-            metadata = extract_metadata_from_xlsx(metadata)
-
-        else:
-            metadata = metadata
-
         anns, base = self.extract_root_idx(input, metadata)
         pecha, layer_path = self.create_pecha(anns, base, metadata, output_path)
         return pecha, layer_path

--- a/src/openpecha/pecha/parsers/google_doc/translation.py
+++ b/src/openpecha/pecha/parsers/google_doc/translation.py
@@ -152,42 +152,6 @@ class GoogleDocTranslationParser(BaseParser):
         pecha, layer_path = self.create_pecha(output_path)
         return pecha, layer_path
 
-    def update_alignment_in_source_pecha(self, target_pecha_layer: str):
-        """
-        Mapping should be updated on source pecha, when translation pecha is created.
-        Such that 'translation_alignments' in the pecha metadata.
-        Input: source_pecha_layer contains the path to source layer.
-
-        Eg: "I3717024E/layers/345F/Tibetan_Segment-4C61.json"
-                -I3717024E -> Pecha id,
-                -345F -> Basename
-                -Tibetan_Segment-4C61.json -> Layer Name
-        """
-        assert isinstance(self.source_path, str)
-        source_pecha_layer = Path(self.source_path)
-        pecha_id = source_pecha_layer.parts[0]
-
-        pecha = Pecha.from_id(pecha_id=pecha_id)
-        pecha_metadata = pecha.metadata
-
-        new_translation_alignment = {
-            "source": self.source_path,
-            "target": target_pecha_layer,
-        }
-
-        if AlignmentEnum.translation_alignment.value in pecha_metadata.source_metadata:
-            pecha_metadata.source_metadata[
-                AlignmentEnum.translation_alignment.value
-            ].append(new_translation_alignment)
-        else:
-            pecha_metadata.source_metadata[
-                AlignmentEnum.translation_alignment.value
-            ] = [new_translation_alignment]
-        pecha.set_metadata(pecha_metadata=pecha_metadata)
-
-        # Update remote pecha
-        pecha.publish()
-
     def create_pecha(self, output_path: Path) -> Tuple[Pecha, Path]:
         pecha = Pecha.create(output_path)
         basename = pecha.set_base(self.base)
@@ -213,9 +177,6 @@ class GoogleDocTranslationParser(BaseParser):
         # Get layer path relative to Pecha Path
         index = layer_path.parts.index(pecha.id)
         relative_layer_path = Path(*layer_path.parts[index:])
-
-        if self.source_path:
-            self.update_alignment_in_source_pecha(str(relative_layer_path))
 
         # Set source path in translation alignment
         if self.source_path:

--- a/tests/alignment/serializers/translation/normal_alignment/test_normal_translation_serializer.py
+++ b/tests/alignment/serializers/translation/normal_alignment/test_normal_translation_serializer.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from unittest import TestCase, mock
 
 from openpecha.alignment.serializers.translation import TextTranslationSerializer
+from openpecha.pecha import Pecha
 from openpecha.utils import read_json
 
 DATA_DIR = Path(__file__).parent / "data"
@@ -34,8 +35,11 @@ class TestTextTranslationSerializer(TestCase):
         root_opf = DATA_DIR / "bo/IE60BBDE8"
         translation_opf = DATA_DIR / "en/I62E00D78"
 
+        root_pecha = Pecha.from_path(root_opf)
+        translation_pecha = Pecha.from_path(translation_opf)
+
         serializer = TextTranslationSerializer()
-        json_output = serializer.serialize(root_opf, translation_opf, False)
+        json_output = serializer.serialize(root_pecha, translation_pecha, False)
 
         expected_json_path = DATA_DIR / "expected_output.json"
         assert json_output == read_json(expected_json_path)
@@ -43,3 +47,9 @@ class TestTextTranslationSerializer(TestCase):
     def tearDown(self):
         # Stop the patch
         self.patcher.stop()
+
+
+serializer = TestTextTranslationSerializer()
+serializer.setUp()
+serializer.test_translation_serializer()
+serializer.tearDown()

--- a/tests/alignment/serializers/translation/pecha_display/test_pecha_display_serializer.py
+++ b/tests/alignment/serializers/translation/pecha_display/test_pecha_display_serializer.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from unittest import TestCase, mock
 
 from openpecha.alignment.serializers.translation import TextTranslationSerializer
+from openpecha.pecha import Pecha
 from openpecha.utils import read_json
 
 DATA_DIR = Path(__file__).parent / "data"
@@ -34,8 +35,10 @@ class TestTextTranslationSerializer(TestCase):
         root_opf = DATA_DIR / "bo/IFA46BBC2"
         translation_opf = DATA_DIR / "en/I6EA29D09"
 
+        root_pecha = Pecha.from_path(root_opf)
+        translation_pecha = Pecha.from_path(translation_opf)
         serializer = TextTranslationSerializer()
-        json_output = serializer.serialize(root_opf, translation_opf)
+        json_output = serializer.serialize(root_pecha, translation_pecha)
 
         expected_json_path = DATA_DIR / "expected_output.json"
         assert json_output == read_json(expected_json_path)

--- a/tests/pecha/parser/google_doc/translation/test_translation.py
+++ b/tests/pecha/parser/google_doc/translation/test_translation.py
@@ -1,5 +1,6 @@
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 from openpecha.pecha import Pecha
 from openpecha.pecha.parsers.google_doc.translation import GoogleDocTranslationParser
@@ -30,11 +31,12 @@ def test_bo_google_doc_translation_parser():
         base == expected_base
     ), "Translation Parser failed preparing base text properly for bo data"
 
-    with tempfile.TemporaryDirectory() as tmpdirname:
+    with tempfile.TemporaryDirectory() as tmpdirname, patch(
+        "openpecha.pecha.parsers.google_doc.translation.GoogleDocTranslationParser.extract_root_idx"
+    ) as mock_extract_root_idx:
         OUTPUT_DIR = Path(tmpdirname)
-        pecha, _ = parser.create_pecha(
-            expected_anns, expected_base, metadata, OUTPUT_DIR
-        )
+        mock_extract_root_idx.return_value = (expected_anns, expected_base)
+        pecha, _ = parser.parse(bo_docx_file, metadata, OUTPUT_DIR)
 
         assert isinstance(pecha, Pecha)
 

--- a/tests/pecha/parser/google_doc/translation/test_translation.py
+++ b/tests/pecha/parser/google_doc/translation/test_translation.py
@@ -36,7 +36,7 @@ def test_bo_google_doc_translation_parser():
     ) as mock_extract_root_idx:
         OUTPUT_DIR = Path(tmpdirname)
         mock_extract_root_idx.return_value = (expected_anns, expected_base)
-        pecha, _ = parser.parse(bo_docx_file, metadata, OUTPUT_DIR)
+        pecha = parser.parse(bo_docx_file, metadata, OUTPUT_DIR)
 
         assert isinstance(pecha, Pecha)
 
@@ -71,7 +71,7 @@ def test_en_google_doc_translation_parser():
     ) as mock_extract_root_idx:
         OUTPUT_DIR = Path(tmpdirname)
         mock_extract_root_idx.return_value = (expected_anns, expected_base)
-        pecha, _ = parser.parse(en_docx_file, metadata, OUTPUT_DIR)
+        pecha = parser.parse(en_docx_file, metadata, OUTPUT_DIR)
 
         assert isinstance(pecha, Pecha)
 
@@ -105,6 +105,6 @@ def test_zh_google_doc_translation_parser():
     ) as mock_extract_root_idx:
         OUTPUT_DIR = Path(tmpdirname)
         mock_extract_root_idx.return_value = (expected_anns, expected_base)
-        pecha, _ = parser.parse(zh_docx_file, metadata, OUTPUT_DIR)
+        pecha = parser.parse(zh_docx_file, metadata, OUTPUT_DIR)
 
         assert isinstance(pecha, Pecha)

--- a/tests/pecha/parser/google_doc/translation/test_translation.py
+++ b/tests/pecha/parser/google_doc/translation/test_translation.py
@@ -41,61 +41,70 @@ def test_bo_google_doc_translation_parser():
         assert isinstance(pecha, Pecha)
 
 
-# def test_en_google_doc_translation_parser():
-#     en_docx_file = DATA_DIR / "en" / "English aligned Root Text Translation.docx"
-#     en_metadata = DATA_DIR / "en" / "English Root text Translation Metadata.xlsx"
+def test_en_google_doc_translation_parser():
+    en_docx_file = DATA_DIR / "en" / "English aligned Root Text Translation.docx"
+    en_metadata = DATA_DIR / "en" / "English Root text Translation Metadata.xlsx"
 
-#     parser = GoogleDocTranslationParser(
-#         source_path="I30EA9E0D/layers/4EE7/Tibetan_Segment-7438.json"
-#     )
-#     with tempfile.TemporaryDirectory() as tmpdirname, patch(""):
-#         OUTPUT_DIR = Path(tmpdirname)
+    parser = GoogleDocTranslationParser(
+        source_path="I30EA9E0D/layers/4EE7/Tibetan_Segment-7438.json"
+    )
 
-#         pecha, _ = parser.parse(
-#             input=en_docx_file,
-#             metadata=en_metadata,
-#             output_path=OUTPUT_DIR,
-#         )
+    expected_anns = [
+        {"English_Segment": {"start": 0, "end": 154}, "root_idx_mapping": "1"},
+        {"English_Segment": {"start": 155, "end": 194}, "root_idx_mapping": "2"},
+        {"English_Segment": {"start": 195, "end": 404}, "root_idx_mapping": "3"},
+    ]
+    expected_base = 'In Sanskrit: Āryavajracchedikā-prajñāpāramitā-nāma-mahāyāna-sūtra In Tibetan: The Noble Mahāyāna Sūtra "The Perfection of Wisdom that Cuts Like a Diamond"\nHomage to all Buddhas and Bodhisattvas.\nThus have I heard at one time: The Blessed One was dwelling in Śrāvastī, in the Jeta Grove, in Anāthapiṇḍada\'s park, together with a great assembly of 1,250 monks and a great number of bodhisattva mahāsattvas.'
 
-#         assert isinstance(pecha, Pecha)
+    metadata = extract_metadata_from_xlsx(en_metadata)
+    anns, base = parser.extract_root_idx(en_docx_file, metadata)
 
-#         assert (
-#             parser.base
-#             == 'In Sanskrit: Āryavajracchedikā-prajñāpāramitā-nāma-mahāyāna-sūtra In Tibetan: The Noble Mahāyāna Sūtra "The Perfection of Wisdom that Cuts Like a Diamond"\nHomage to all Buddhas and Bodhisattvas.\nThus have I heard at one time: The Blessed One was dwelling in Śrāvastī, in the Jeta Grove, in Anāthapiṇḍada\'s park, together with a great assembly of 1,250 monks and a great number of bodhisattva mahāsattvas.'
-#         )
-#         expected_anns = [
-#             {"English_Segment": {"start": 0, "end": 154}, "root_idx_mapping": "1"},
-#             {"English_Segment": {"start": 155, "end": 194}, "root_idx_mapping": "2"},
-#             {"English_Segment": {"start": 195, "end": 404}, "root_idx_mapping": "3"},
-#         ]
-#         assert parser.anns == expected_anns
+    assert (
+        anns == expected_anns
+    ), "Translation Parser failed parsing Root anns properly for en data."
+    assert (
+        base == expected_base
+    ), "Translation Parser failed preparing base text properly for en data"
+
+    with tempfile.TemporaryDirectory() as tmpdirname, patch(
+        "openpecha.pecha.parsers.google_doc.translation.GoogleDocTranslationParser.extract_root_idx"
+    ) as mock_extract_root_idx:
+        OUTPUT_DIR = Path(tmpdirname)
+        mock_extract_root_idx.return_value = (expected_anns, expected_base)
+        pecha, _ = parser.parse(en_docx_file, metadata, OUTPUT_DIR)
+
+        assert isinstance(pecha, Pecha)
 
 
-# def test_zh_google_doc_translation_parser():
-#     en_docx_file = DATA_DIR / "zh" / "Chinese aligned Root Text Translation.docx"
-#     en_metadata = DATA_DIR / "zh" / "Chinese Root text Translation Metadata.xlsx"
+def test_zh_google_doc_translation_parser():
+    zh_docx_file = DATA_DIR / "zh" / "Chinese aligned Root Text Translation.docx"
+    zh_metadata = DATA_DIR / "zh" / "Chinese Root text Translation Metadata.xlsx"
 
-#     parser = GoogleDocTranslationParser(
-#         source_path="I30EA9E0D/layers/4EE7/Tibetan_Segment-7438.json"
-#     )
-#     with tempfile.TemporaryDirectory() as tmpdirname:
-#         OUTPUT_DIR = Path(tmpdirname)
+    parser = GoogleDocTranslationParser(
+        source_path="I30EA9E0D/layers/4EE7/Tibetan_Segment-7438.json"
+    )
+    expected_anns = [
+        {"Chinese_Segment": {"start": 0, "end": 72}, "root_idx_mapping": "1"},
+        {"Chinese_Segment": {"start": 73, "end": 81}, "root_idx_mapping": "2"},
+        {"Chinese_Segment": {"start": 82, "end": 125}, "root_idx_mapping": "3"},
+    ]
+    expected_base = "梵文：Āryavajracchedikā-prajñāpāramitā-nāma-mahāyāna-sūtra 藏文：圣般若波罗蜜多金刚经大乘经\n礼敬一切佛菩萨。\n如是我闻，一时：佛在舍卫国祇树给孤独园，与大比丘众千二百五十人俱，并诸菩萨摩诃萨众多。"
 
-#         pecha, _ = parser.parse(
-#             input=en_docx_file,
-#             metadata=en_metadata,
-#             output_path=OUTPUT_DIR,
-#         )
+    metadata = extract_metadata_from_xlsx(zh_metadata)
+    anns, base = parser.extract_root_idx(zh_docx_file, metadata)
 
-#         assert isinstance(pecha, Pecha)
+    assert (
+        anns == expected_anns
+    ), "Translation Parser failed parsing Root anns properly for zh data."
+    assert (
+        base == expected_base
+    ), "Translation Parser failed preparing base text properly for zh data"
 
-#         assert (
-#             parser.base
-#             == "梵文：Āryavajracchedikā-prajñāpāramitā-nāma-mahāyāna-sūtra 藏文：圣般若波罗蜜多金刚经大乘经\n礼敬一切佛菩萨。\n如是我闻，一时：佛在舍卫国祇树给孤独园，与大比丘众千二百五十人俱，并诸菩萨摩诃萨众多。"
-#         )
-#         expected_anns = [
-#             {"Chinese_Segment": {"start": 0, "end": 72}, "root_idx_mapping": "1"},
-#             {"Chinese_Segment": {"start": 73, "end": 81}, "root_idx_mapping": "2"},
-#             {"Chinese_Segment": {"start": 82, "end": 125}, "root_idx_mapping": "3"},
-#         ]
-#         assert parser.anns == expected_anns
+    with tempfile.TemporaryDirectory() as tmpdirname, patch(
+        "openpecha.pecha.parsers.google_doc.translation.GoogleDocTranslationParser.extract_root_idx"
+    ) as mock_extract_root_idx:
+        OUTPUT_DIR = Path(tmpdirname)
+        mock_extract_root_idx.return_value = (expected_anns, expected_base)
+        pecha, _ = parser.parse(zh_docx_file, metadata, OUTPUT_DIR)
+
+        assert isinstance(pecha, Pecha)

--- a/tests/pecha/parser/google_doc/translation/test_translation.py
+++ b/tests/pecha/parser/google_doc/translation/test_translation.py
@@ -1,6 +1,5 @@
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
 from openpecha.pecha import Pecha
 from openpecha.pecha.parsers.google_doc.translation import GoogleDocTranslationParser
@@ -42,11 +41,8 @@ def test_en_google_doc_translation_parser():
     parser = GoogleDocTranslationParser(
         source_path="I30EA9E0D/layers/4EE7/Tibetan_Segment-7438.json"
     )
-    with tempfile.TemporaryDirectory() as tmpdirname, patch(
-        "openpecha.pecha.parsers.google_doc.translation.GoogleDocTranslationParser.update_alignment_in_source_pecha"
-    ) as mock_update_source_pecha:
+    with tempfile.TemporaryDirectory() as tmpdirname:
         OUTPUT_DIR = Path(tmpdirname)
-        mock_update_source_pecha.return_value = None
 
         pecha, _ = parser.parse(
             input=en_docx_file,
@@ -75,11 +71,8 @@ def test_zh_google_doc_translation_parser():
     parser = GoogleDocTranslationParser(
         source_path="I30EA9E0D/layers/4EE7/Tibetan_Segment-7438.json"
     )
-    with tempfile.TemporaryDirectory() as tmpdirname, patch(
-        "openpecha.pecha.parsers.google_doc.translation.GoogleDocTranslationParser.update_alignment_in_source_pecha"
-    ) as mock_update_source_pecha:
+    with tempfile.TemporaryDirectory() as tmpdirname:
         OUTPUT_DIR = Path(tmpdirname)
-        mock_update_source_pecha.return_value = None
 
         pecha, _ = parser.parse(
             input=en_docx_file,

--- a/tests/pecha/parser/google_doc/translation/test_translation.py
+++ b/tests/pecha/parser/google_doc/translation/test_translation.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from openpecha.pecha import Pecha
 from openpecha.pecha.parsers.google_doc.translation import GoogleDocTranslationParser
+from openpecha.pecha.parsers.parser_utils import extract_metadata_from_xlsx
 
 DATA_DIR = Path(__file__).parent / "data"
 
@@ -12,83 +13,87 @@ def test_bo_google_doc_translation_parser():
     bo_metadata = DATA_DIR / "bo" / "Tibetan Root text Translation Metadata.xlsx"
 
     parser = GoogleDocTranslationParser()
+
+    expected_anns = [
+        {"Tibetan_Segment": {"start": 0, "end": 158}, "root_idx_mapping": "1"},
+        {"Tibetan_Segment": {"start": 159, "end": 210}, "root_idx_mapping": "2"},
+        {"Tibetan_Segment": {"start": 211, "end": 470}, "root_idx_mapping": "3"},
+    ]
+    expected_base = "རྒྱ་གར་སྐད་དུ། ཨརྱཱ་བཛྲ་ཙྪེད་ཀ་པྲཛྙཱ་པ་ར་མི་ཏཱ་ནཱ་མ་མ་ཧཱ་ཡ་ན་སཱུ་ཏྲ། བོད་སྐད་དུ། འཕགས་པ་ཤེས་རབ་ཀྱི་ཕ་རོལ་ཏུ་ཕྱིན་པ་རྡོ་རྗེ་གཅོད་པ་ཞེས་བྱ་བ་ཐེག་པ་ཆེན་པོའི་མདོ།\nསངས་རྒྱས་དང་བྱང་ཆུབ་སེམས་དཔའ་ཐམས་ཅད་ལ་ཕྱག་འཚལ་ལོ། །\nའདི་སྐད་བདག་གིས་ཐོས་པ་དུས་གཅིག་ན།  བཅོམ་ལྡན་འདས་མཉན་ཡོད་ན་རྒྱལ་བུ་རྒྱལ་བྱེད་ཀྱི་ཚལ་མགོན་མེད་ཟས་སྦྱིན་གྱི་ཀུན་དགའ་ར་བ་ན། དགེ་སློང་སྟོང་ཉིས་བརྒྱ་ལྔ་བཅུའི་དགེ་སློང་གི་དགེ་འདུན་ཆེན་པོ་དང༌། བྱང་ཆུབ་སེམས་དཔའ་སེམས་དཔའ་ཆེན་པོ་རབ་ཏུ་མང་པོ་དག་དང་ཐབས་གཅིག་ཏུ་བཞུགས་སོ། །"
+    metadata = extract_metadata_from_xlsx(bo_metadata)
+    anns, base = parser.extract_root_idx(bo_docx_file, metadata)
+
+    assert (
+        anns == expected_anns
+    ), "Translation Parser failed parsing Root anns properly for bo data."
+    assert (
+        base == expected_base
+    ), "Translation Parser failed preparing base text properly for bo data"
+
     with tempfile.TemporaryDirectory() as tmpdirname:
         OUTPUT_DIR = Path(tmpdirname)
-        pecha, _ = parser.parse(
-            input=bo_docx_file,
-            metadata=bo_metadata,
-            output_path=OUTPUT_DIR,
+        pecha, _ = parser.create_pecha(
+            expected_anns, expected_base, metadata, OUTPUT_DIR
         )
 
         assert isinstance(pecha, Pecha)
 
-        assert (
-            parser.base
-            == "རྒྱ་གར་སྐད་དུ། ཨརྱཱ་བཛྲ་ཙྪེད་ཀ་པྲཛྙཱ་པ་ར་མི་ཏཱ་ནཱ་མ་མ་ཧཱ་ཡ་ན་སཱུ་ཏྲ། བོད་སྐད་དུ། འཕགས་པ་ཤེས་རབ་ཀྱི་ཕ་རོལ་ཏུ་ཕྱིན་པ་རྡོ་རྗེ་གཅོད་པ་ཞེས་བྱ་བ་ཐེག་པ་ཆེན་པོའི་མདོ།\nསངས་རྒྱས་དང་བྱང་ཆུབ་སེམས་དཔའ་ཐམས་ཅད་ལ་ཕྱག་འཚལ་ལོ། །\nའདི་སྐད་བདག་གིས་ཐོས་པ་དུས་གཅིག་ན།  བཅོམ་ལྡན་འདས་མཉན་ཡོད་ན་རྒྱལ་བུ་རྒྱལ་བྱེད་ཀྱི་ཚལ་མགོན་མེད་ཟས་སྦྱིན་གྱི་ཀུན་དགའ་ར་བ་ན། དགེ་སློང་སྟོང་ཉིས་བརྒྱ་ལྔ་བཅུའི་དགེ་སློང་གི་དགེ་འདུན་ཆེན་པོ་དང༌། བྱང་ཆུབ་སེམས་དཔའ་སེམས་དཔའ་ཆེན་པོ་རབ་ཏུ་མང་པོ་དག་དང་ཐབས་གཅིག་ཏུ་བཞུགས་སོ། །"
-        )
-        expected_anns = [
-            {"Tibetan_Segment": {"start": 0, "end": 158}, "root_idx_mapping": "1"},
-            {"Tibetan_Segment": {"start": 159, "end": 210}, "root_idx_mapping": "2"},
-            {"Tibetan_Segment": {"start": 211, "end": 470}, "root_idx_mapping": "3"},
-        ]
-        assert parser.anns == expected_anns
+
+# def test_en_google_doc_translation_parser():
+#     en_docx_file = DATA_DIR / "en" / "English aligned Root Text Translation.docx"
+#     en_metadata = DATA_DIR / "en" / "English Root text Translation Metadata.xlsx"
+
+#     parser = GoogleDocTranslationParser(
+#         source_path="I30EA9E0D/layers/4EE7/Tibetan_Segment-7438.json"
+#     )
+#     with tempfile.TemporaryDirectory() as tmpdirname, patch(""):
+#         OUTPUT_DIR = Path(tmpdirname)
+
+#         pecha, _ = parser.parse(
+#             input=en_docx_file,
+#             metadata=en_metadata,
+#             output_path=OUTPUT_DIR,
+#         )
+
+#         assert isinstance(pecha, Pecha)
+
+#         assert (
+#             parser.base
+#             == 'In Sanskrit: Āryavajracchedikā-prajñāpāramitā-nāma-mahāyāna-sūtra In Tibetan: The Noble Mahāyāna Sūtra "The Perfection of Wisdom that Cuts Like a Diamond"\nHomage to all Buddhas and Bodhisattvas.\nThus have I heard at one time: The Blessed One was dwelling in Śrāvastī, in the Jeta Grove, in Anāthapiṇḍada\'s park, together with a great assembly of 1,250 monks and a great number of bodhisattva mahāsattvas.'
+#         )
+#         expected_anns = [
+#             {"English_Segment": {"start": 0, "end": 154}, "root_idx_mapping": "1"},
+#             {"English_Segment": {"start": 155, "end": 194}, "root_idx_mapping": "2"},
+#             {"English_Segment": {"start": 195, "end": 404}, "root_idx_mapping": "3"},
+#         ]
+#         assert parser.anns == expected_anns
 
 
-def test_en_google_doc_translation_parser():
-    en_docx_file = DATA_DIR / "en" / "English aligned Root Text Translation.docx"
-    en_metadata = DATA_DIR / "en" / "English Root text Translation Metadata.xlsx"
+# def test_zh_google_doc_translation_parser():
+#     en_docx_file = DATA_DIR / "zh" / "Chinese aligned Root Text Translation.docx"
+#     en_metadata = DATA_DIR / "zh" / "Chinese Root text Translation Metadata.xlsx"
 
-    parser = GoogleDocTranslationParser(
-        source_path="I30EA9E0D/layers/4EE7/Tibetan_Segment-7438.json"
-    )
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        OUTPUT_DIR = Path(tmpdirname)
+#     parser = GoogleDocTranslationParser(
+#         source_path="I30EA9E0D/layers/4EE7/Tibetan_Segment-7438.json"
+#     )
+#     with tempfile.TemporaryDirectory() as tmpdirname:
+#         OUTPUT_DIR = Path(tmpdirname)
 
-        pecha, _ = parser.parse(
-            input=en_docx_file,
-            metadata=en_metadata,
-            output_path=OUTPUT_DIR,
-        )
+#         pecha, _ = parser.parse(
+#             input=en_docx_file,
+#             metadata=en_metadata,
+#             output_path=OUTPUT_DIR,
+#         )
 
-        assert isinstance(pecha, Pecha)
+#         assert isinstance(pecha, Pecha)
 
-        assert (
-            parser.base
-            == 'In Sanskrit: Āryavajracchedikā-prajñāpāramitā-nāma-mahāyāna-sūtra In Tibetan: The Noble Mahāyāna Sūtra "The Perfection of Wisdom that Cuts Like a Diamond"\nHomage to all Buddhas and Bodhisattvas.\nThus have I heard at one time: The Blessed One was dwelling in Śrāvastī, in the Jeta Grove, in Anāthapiṇḍada\'s park, together with a great assembly of 1,250 monks and a great number of bodhisattva mahāsattvas.'
-        )
-        expected_anns = [
-            {"English_Segment": {"start": 0, "end": 154}, "root_idx_mapping": "1"},
-            {"English_Segment": {"start": 155, "end": 194}, "root_idx_mapping": "2"},
-            {"English_Segment": {"start": 195, "end": 404}, "root_idx_mapping": "3"},
-        ]
-        assert parser.anns == expected_anns
-
-
-def test_zh_google_doc_translation_parser():
-    en_docx_file = DATA_DIR / "zh" / "Chinese aligned Root Text Translation.docx"
-    en_metadata = DATA_DIR / "zh" / "Chinese Root text Translation Metadata.xlsx"
-
-    parser = GoogleDocTranslationParser(
-        source_path="I30EA9E0D/layers/4EE7/Tibetan_Segment-7438.json"
-    )
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        OUTPUT_DIR = Path(tmpdirname)
-
-        pecha, _ = parser.parse(
-            input=en_docx_file,
-            metadata=en_metadata,
-            output_path=OUTPUT_DIR,
-        )
-
-        assert isinstance(pecha, Pecha)
-
-        assert (
-            parser.base
-            == "梵文：Āryavajracchedikā-prajñāpāramitā-nāma-mahāyāna-sūtra 藏文：圣般若波罗蜜多金刚经大乘经\n礼敬一切佛菩萨。\n如是我闻，一时：佛在舍卫国祇树给孤独园，与大比丘众千二百五十人俱，并诸菩萨摩诃萨众多。"
-        )
-        expected_anns = [
-            {"Chinese_Segment": {"start": 0, "end": 72}, "root_idx_mapping": "1"},
-            {"Chinese_Segment": {"start": 73, "end": 81}, "root_idx_mapping": "2"},
-            {"Chinese_Segment": {"start": 82, "end": 125}, "root_idx_mapping": "3"},
-        ]
-        assert parser.anns == expected_anns
+#         assert (
+#             parser.base
+#             == "梵文：Āryavajracchedikā-prajñāpāramitā-nāma-mahāyāna-sūtra 藏文：圣般若波罗蜜多金刚经大乘经\n礼敬一切佛菩萨。\n如是我闻，一时：佛在舍卫国祇树给孤独园，与大比丘众千二百五十人俱，并诸菩萨摩诃萨众多。"
+#         )
+#         expected_anns = [
+#             {"Chinese_Segment": {"start": 0, "end": 72}, "root_idx_mapping": "1"},
+#             {"Chinese_Segment": {"start": 73, "end": 81}, "root_idx_mapping": "2"},
+#             {"Chinese_Segment": {"start": 82, "end": 125}, "root_idx_mapping": "3"},
+#         ]
+#         assert parser.anns == expected_anns


### PR DESCRIPTION
Fixes:
- Avoid updating the Root OPF when publishing a translation OPF
- take metadata input as a dictionary, not XLSX.
- Return Pecha only from TranslationParser.
- Make the serializer and parser static