### PR TITLE
Pecha org pecha metadata validator

### DIFF
--- a/src/openpecha/exceptions.py
+++ b/src/openpecha/exceptions.py
@@ -70,6 +70,12 @@ class BaseUpdateFailedError(Exception):
     pass
 
 
+class AlignmentDataMissingError(Exception):
+    """Raised when the alignment information is missing."""
+
+    pass
+
+
 class AlignmentDataKeyMissingError(Exception):
     """Raised when the alignment information key is missing."""
 

--- a/src/openpecha/exceptions.py
+++ b/src/openpecha/exceptions.py
@@ -104,3 +104,9 @@ class RootPechaNotFoundError(Exception):
     """Raised when the root pecha is not found."""
 
     pass
+
+
+class PechaCategoryNotFoundError(Exception):
+    """Raised when the pecha category is not found."""
+
+    pass

--- a/src/openpecha/pecha/parsers/docx/__init__.py
+++ b/src/openpecha/pecha/parsers/docx/__init__.py
@@ -1,11 +1,68 @@
 from pathlib import Path
 from typing import Dict, List, Union
 
+from openpecha.config import get_logger
+from openpecha.exceptions import MetaDataMissingError, MetaDataValidationError
 from openpecha.pecha import Pecha
 from openpecha.pecha.parsers.docx.commentary.simple import DocxSimpleCommentaryParser
 from openpecha.pecha.parsers.docx.numberlist_translation import (
     DocxNumberListTranslationParser,
 )
+
+logger = get_logger(__name__)
+
+
+class PechaOrgPechaMetaDataValidator:
+    def validate_metadata(self, metadata: Dict):
+        self.validate_metadata_dtype(metadata)
+        self.validate_en_title(metadata)
+        self.validate_bo_title(metadata)
+        self.validate_lang_title(metadata)
+
+    def ensure_no_forbidden_symbols(self, title: str):
+        symbols = ["-", ":", "_"]
+        for symbol in symbols:
+            if symbol in title:
+                logger.error(f"Title can't have symbol {symbol}")
+                raise MetaDataValidationError(f"Title can't have symbol {symbol}")
+        pass
+
+    def validate_metadata_dtype(self, metadata: Dict):
+        if not isinstance(metadata, dict):
+            logger.error("Input metadata should be a dictionary")
+            raise TypeError("Input metadata should be a dictionary")
+
+    def validate_en_title(self, metadata: Dict):
+        en_title = metadata.get("title", {}).get("en", None)
+
+        if not en_title:
+            logger.error("English title is missing in metadata")
+            raise MetaDataMissingError("English title is missing in metadata")
+
+        self.ensure_no_forbidden_symbols(en_title)
+
+    def validate_bo_title(self, metadata: Dict):
+        bo_title = metadata.get("title", {}).get("bo", None)
+
+        if not bo_title:
+            logger.error("Tibetan title is missing in metadata")
+            raise MetaDataMissingError("Tibetan title is missing in metadata")
+
+        self.ensure_no_forbidden_symbols(bo_title)
+
+    def validate_lang_title(self, metadata: Dict):
+        lang = metadata.get("lang", None)
+
+        if not lang:
+            logger.error("Language is missing in metadata")
+            raise MetaDataMissingError("Language is missing in metadata")
+
+        lang_title = metadata.get("title", {}).get(lang, None)
+        if not lang_title:
+            logger.error(f"{lang} title is missing in metadata")
+            raise MetaDataMissingError(f"{lang} title is missing in metadata")
+
+        self.ensure_no_forbidden_symbols(lang_title)
 
 
 class DocxParser:

--- a/src/openpecha/pecha/parsers/docx/__init__.py
+++ b/src/openpecha/pecha/parsers/docx/__init__.py
@@ -20,12 +20,11 @@ class PechaOrgPechaMetaDataValidator:
         self.validate_lang_title(metadata)
 
     def ensure_no_forbidden_symbols(self, title: str):
-        symbols = ["-", ":", "_"]
+        symbols = ["-", ":", "_", ".", "/"]
         for symbol in symbols:
             if symbol in title:
                 logger.error(f"Title can't have symbol {symbol}")
                 raise MetaDataValidationError(f"Title can't have symbol {symbol}")
-        pass
 
     def validate_metadata_dtype(self, metadata: Dict):
         if not isinstance(metadata, dict):

--- a/src/openpecha/pecha/serializers/pecha_db/__init__.py
+++ b/src/openpecha/pecha/serializers/pecha_db/__init__.py
@@ -94,7 +94,7 @@ class Serializer:
                 )
             commentary_serializer = SimpleCommentarySerializer()
             root_en_title = self.get_root_en_title(metadatas, pechas)
-            root_pecha = self.get_root_pecha(pechas)
+            root_pecha = pechas[1]
             if is_translation:
                 return commentary_serializer.serialize(
                     pecha, alignment_data, root_en_title, root_pecha

--- a/src/openpecha/pecha/serializers/pecha_db/__init__.py
+++ b/src/openpecha/pecha/serializers/pecha_db/__init__.py
@@ -94,17 +94,14 @@ class Serializer:
                 )
             commentary_serializer = SimpleCommentarySerializer()
             root_en_title = self.get_root_en_title(metadatas, pechas)
-            root_pecha = pechas[1]
+            commentary_pecha = pechas[1]
             if is_translation:
                 return commentary_serializer.serialize(
-                    pecha, alignment_data, root_en_title, root_pecha
+                    pecha, alignment_data, root_en_title, commentary_pecha
                 )
             return commentary_serializer.serialize(pecha, alignment_data, root_en_title)
 
         # Root Pecha or Translation of Root Pecha
         root_serializer = TranslationSerializer()
-        return root_serializer.serialize(
-            pecha,
-            alignment_data,
-            self.get_root_pecha(pechas) if is_translation else None,
-        )
+        root_pecha = self.get_root_pecha(pechas) if is_translation else None
+        return root_serializer.serialize(pecha, alignment_data, root_pecha)

--- a/src/openpecha/pecha/serializers/pecha_db/__init__.py
+++ b/src/openpecha/pecha/serializers/pecha_db/__init__.py
@@ -51,7 +51,7 @@ class Serializer:
                 f"Title should be a dictionary in Root Pecha {root_pecha.id}."
             )
 
-        en_title = title.get("en")
+        en_title = next((title[key] for key in title if key.lower() == "en"), None)
 
         if not en_title:
             logger.error(f"English title is missing in Root Pecha {root_pecha.id}.")

--- a/src/openpecha/pecha/serializers/pecha_db/commentary/simple_commentary.py
+++ b/src/openpecha/pecha/serializers/pecha_db/commentary/simple_commentary.py
@@ -132,7 +132,20 @@ class SimpleCommentarySerializer:
         commentary_pecha: Union[Pecha, None] = None,
     ):
         """
-        Serialize the commentary pecha to json format
+        Commentary Pecha can be i) Commentary Pecha ii) Translation of Commentary Pecha
+        if Commentary Pecha,
+            pecha: Commentary Pecha
+            alignment_data: 'commentary_of' mapping with Root Pecha
+            root_title: Root Pecha title
+            commentary_pecha: None
+
+        if Translation of Commentary Pecha,
+            pecha: Translation of Commentary Pecha
+            alignment_data: 'translation_of' mapping with Commentary Pecha
+            root_title: Root Pecha title
+            commentary_pecha: Commentary Pecha
+
+        Output: Serialized JSON of Commentary Pecha
         """
 
         src_book, tgt_book = [], []

--- a/src/openpecha/pecha/serializers/pecha_db/commentary/simple_commentary.py
+++ b/src/openpecha/pecha/serializers/pecha_db/commentary/simple_commentary.py
@@ -4,7 +4,11 @@ from pecha_org_tools.extract import CategoryExtractor
 from stam import AnnotationStore
 
 from openpecha.config import get_logger
-from openpecha.exceptions import MetaDataValidationError, RootPechaNotFoundError
+from openpecha.exceptions import (
+    MetaDataValidationError,
+    PechaCategoryNotFoundError,
+    RootPechaNotFoundError,
+)
 from openpecha.pecha import Pecha
 from openpecha.pecha.metadata import PechaMetaData
 from openpecha.utils import get_text_direction_with_lang
@@ -63,7 +67,15 @@ class SimpleCommentarySerializer:
         """
 
         categorizer = CategoryExtractor()
-        category = categorizer.get_category(category_name)
+        try:
+            category = categorizer.get_category(category_name)
+        except Exception as e:
+            logger.error(
+                f"Category not found for pecha title: {category_name}. {str(e)}"
+            )
+            raise PechaCategoryNotFoundError(
+                f"Category not found for pecha title: {category_name}. {str(e)}"
+            )
         return category
 
     def add_root_reference_to_category(self, category: Dict[str, Any], root_title: str):

--- a/src/openpecha/pecha/serializers/pecha_db/commentary/simple_commentary.py
+++ b/src/openpecha/pecha/serializers/pecha_db/commentary/simple_commentary.py
@@ -129,7 +129,7 @@ class SimpleCommentarySerializer:
         pecha: Pecha,
         alignment_data: Dict,
         root_title: str,
-        root_pecha: Union[Pecha, None] = None,
+        commentary_pecha: Union[Pecha, None] = None,
     ):
         """
         Serialize the commentary pecha to json format
@@ -143,7 +143,7 @@ class SimpleCommentarySerializer:
         src_category, tgt_category = self.get_categories(pecha, root_title)
 
         if "translation_of" in pecha.metadata.source_metadata:
-            if not root_pecha or not isinstance(root_pecha, Pecha):
+            if not commentary_pecha or not isinstance(commentary_pecha, Pecha):
                 logger.error(
                     "Root pecha is not passed during Commentary Translation Serialization."
                 )
@@ -154,7 +154,7 @@ class SimpleCommentarySerializer:
             commentary_path = alignment_data["source"]
             tgt_layer_path = alignment_data["target"]
             src_content = self.get_content(pecha, translation_path)
-            tgt_content = self.get_content(root_pecha, commentary_path)
+            tgt_content = self.get_content(commentary_pecha, commentary_path)
         else:
             tgt_layer_path = alignment_data["target"]
             src_content = []

--- a/src/openpecha/pecha/serializers/pecha_db/translation.py
+++ b/src/openpecha/pecha/serializers/pecha_db/translation.py
@@ -142,6 +142,20 @@ class TranslationSerializer:
         alignment_data: Union[Dict, None] = None,
         root_pecha: Union[Pecha, None] = None,
     ) -> Dict:
+        """
+        Root Pecha can be i) Root Pecha ii) Translation of Root Pecha
+        if Root Pecha,
+            pecha: Root Pecha
+            alignment_data: None
+            root_pecha: None
+
+        if Translation of Root Pecha,
+            pecha: Translation of Root Pecha
+            alignment_data: 'translation_of' mapping with Root Pecha
+            root_pecha: Root Pecha
+
+        Output: JSON format for pecha_org
+        """
 
         if alignment_data:
             if "source" not in alignment_data or "target" not in alignment_data:

--- a/tests/pecha/parser/docx/docx_parser/test_pechaorg_validator.py
+++ b/tests/pecha/parser/docx/docx_parser/test_pechaorg_validator.py
@@ -1,0 +1,58 @@
+import pytest
+
+from openpecha.exceptions import MetaDataMissingError, MetaDataValidationError
+from openpecha.pecha.parsers.docx import PechaOrgPechaMetaDataValidator
+
+
+@pytest.fixture
+def validator():
+    return PechaOrgPechaMetaDataValidator()
+
+
+def test_validate_metadata_dtype(validator):
+    with pytest.raises(TypeError, match="Input metadata should be a dictionary"):
+        validator.validate_metadata_dtype("invalid_type")
+
+
+def test_validate_en_title_missing(validator):
+    metadata = {"title": {"bo": "བོད་ཀྱི་མིང་"}, "lang": "bo"}
+    with pytest.raises(
+        MetaDataMissingError, match="English title is missing in metadata"
+    ):
+        validator.validate_en_title(metadata)
+
+
+def test_validate_bo_title_missing(validator):
+    metadata = {"title": {"en": "English Title"}, "lang": "bo"}
+    with pytest.raises(
+        MetaDataMissingError, match="Tibetan title is missing in metadata"
+    ):
+        validator.validate_bo_title(metadata)
+
+
+def test_validate_lang_title_missing(validator):
+    metadata = {"title": {"en": "English Title", "bo": "བོད་ཀྱི་མིང་"}, "lang": "fr"}
+    with pytest.raises(MetaDataMissingError, match="fr title is missing in metadata"):
+        validator.validate_lang_title(metadata)
+
+
+def test_ensure_no_forbidden_symbols(validator):
+    with pytest.raises(MetaDataValidationError, match="Title can't have symbol -"):
+        validator.ensure_no_forbidden_symbols("Invalid-Title")
+
+    with pytest.raises(MetaDataValidationError, match="Title can't have symbol :"):
+        validator.ensure_no_forbidden_symbols("Invalid:Title")
+
+    with pytest.raises(MetaDataValidationError, match="Title can't have symbol _"):
+        validator.ensure_no_forbidden_symbols("Invalid_Title")
+
+
+def test_validate_metadata_success(validator):
+    metadata = {
+        "title": {"en": "Valid Title", "bo": "བོད་ཀྱི་མིང་", "fr": "Titre Français"},
+        "lang": "bo",
+    }
+    try:
+        validator.validate_metadata(metadata)
+    except Exception as e:
+        pytest.fail(f"Validation failed unexpectedly: {e}")

--- a/tests/pecha/parser/docx/docx_parser/test_pechaorg_validator.py
+++ b/tests/pecha/parser/docx/docx_parser/test_pechaorg_validator.py
@@ -46,6 +46,12 @@ def test_ensure_no_forbidden_symbols(validator):
     with pytest.raises(MetaDataValidationError, match="Title can't have symbol _"):
         validator.ensure_no_forbidden_symbols("Invalid_Title")
 
+    with pytest.raises(MetaDataValidationError, match="Title can't have symbol ."):
+        validator.ensure_no_forbidden_symbols("Invalid.Title")
+
+    with pytest.raises(MetaDataValidationError, match="Title can't have symbol /"):
+        validator.ensure_no_forbidden_symbols("Invalid/Title")
+
 
 def test_validate_metadata_success(validator):
     metadata = {

--- a/tests/pecha/serializers/pecha_db/serializer/test_serializer.py
+++ b/tests/pecha/serializers/pecha_db/serializer/test_serializer.py
@@ -101,23 +101,6 @@ class TestSerializerGetRootEnTitle(TestCase):
     def setUp(self):
         self.serializer = Serializer()
 
-    def test_root_pecha(self):
-        metadatas: list[MetadataType] = [
-            {
-                "translation_of": None,
-                "commentary_of": None,
-                "version_of": None,
-                "title": {
-                    "en": "Entering the middle Way Chapter 6",
-                    "bo": "མངོན་དུ་ཕྱོགས་པར་མཉམ་བཞག་སེམས་གནས་ཏེ།",
-                },
-            },
-        ]
-        assert (
-            self.serializer.get_root_en_title(metadatas)
-            == "Entering the middle Way Chapter 6"
-        )
-
     def test_commentary_pecha(self):
         metadatas: list[MetadataType] = [
             {

--- a/tests/pecha/serializers/pecha_db/serializer/test_serializer.py
+++ b/tests/pecha/serializers/pecha_db/serializer/test_serializer.py
@@ -171,16 +171,28 @@ class TestSerializer(TestCase):
             self.root_pecha, alignment_data, None
         )
 
-    def test_root_translation_pecha(self):
-        pass
+    @mock.patch(
+        "openpecha.pecha.serializers.pecha_db.translation.TranslationSerializer.serialize"
+    )
+    def test_root_translation_pecha(self, mock_translation_serialize):
+        mock_translation_serialize.return_value = {}
+
+        pechas = [self.root_translation_pecha, self.root_pecha]
+        metadatas = [self.root_translation_pecha_metadata, self.root_pecha_metadata]
+        alignment_data = {
+            "source": "IE60BBDE8/layers/3635/Tibetan_Segment-039B.json",
+            "target": "I62E00D78/layers/D93E/English_Segment-0216.json",
+        }
+        serializer = Serializer()
+        serializer.serialize(pechas, metadatas, alignment_data)
+
+        mock_translation_serialize.assert_called_once()
+        mock_translation_serialize.assert_called_with(
+            self.root_translation_pecha, alignment_data, self.root_pecha
+        )
 
     def test_commentary_pecha(self):
         pass
 
     def test_commentary_translation_pecha(self):
         pass
-
-
-work = TestSerializer()
-work.setUp()
-work.test_root_pecha()

--- a/tests/pecha/serializers/pecha_db/serializer/test_serializer.py
+++ b/tests/pecha/serializers/pecha_db/serializer/test_serializer.py
@@ -141,7 +141,9 @@ class TestSerializer(TestCase):
         self.commentary_pecha = Pecha.from_path(
             Path("tests/pecha/serializers/pecha_db/commentary/simple/data/bo/I6944984E")
         )
-        # self.commentary_translation_pecha = Pecha.from_path("")
+        self.commentary_translation_pecha = Pecha.from_path(
+            Path("tests/pecha/serializers/pecha_db/commentary/simple/data/en/I94DBDA91")
+        )
         self.root_pecha_metadata = {
             "translation_of": None,
             "commentary_of": None,
@@ -159,6 +161,12 @@ class TestSerializer(TestCase):
             "commentary_of": "IE60BBDE8",
             "version_of": None,
             **self.commentary_pecha.metadata.to_dict(),
+        }
+        self.commentary_translation_pecha_metadata = {
+            "translation_of": "I6944984E",
+            "commentary_of": None,
+            "version_of": None,
+            **self.commentary_translation_pecha.metadata.to_dict(),
         }
 
     @mock.patch(
@@ -219,10 +227,33 @@ class TestSerializer(TestCase):
             self.commentary_pecha, alignment_data, self.root_pecha.metadata.title["EN"]
         )
 
-    def test_commentary_translation_pecha(self):
-        pass
+    @mock.patch(
+        "openpecha.pecha.serializers.pecha_db.commentary.simple_commentary.SimpleCommentarySerializer.serialize"
+    )
+    def test_commentary_translation_pecha(self, mock_commentary_serialize):
+        mock_commentary_serialize.return_value = {}
+        pechas = [
+            self.commentary_translation_pecha,
+            self.commentary_pecha,
+            self.root_pecha,
+        ]
+        metadatas = [
+            self.commentary_translation_pecha_metadata,
+            self.commentary_pecha_metadata,
+            self.root_pecha_metadata,
+        ]
+        alignment_data = {
+            "source": "I6944984E/layers/E949/Meaning_Segment-2F29.json",
+            "target": "I94DBDA91/layers/FD22/Meaning_Segment-599A.json",
+        }
 
+        serializer = Serializer()
+        serializer.serialize(pechas, metadatas, alignment_data)
 
-work = TestSerializer()
-work.setUp()
-work.test_commentary_pecha()
+        mock_commentary_serialize.assert_called_once()
+        mock_commentary_serialize.assert_called_with(
+            self.commentary_translation_pecha,
+            alignment_data,
+            self.root_pecha.metadata.title["EN"],
+            self.commentary_pecha,
+        )

--- a/tests/pecha/serializers/pecha_db/serializer/test_serializer.py
+++ b/tests/pecha/serializers/pecha_db/serializer/test_serializer.py
@@ -1,6 +1,8 @@
+from pathlib import Path
 from typing import Dict, List, Union
-from unittest import TestCase
+from unittest import TestCase, mock
 
+from openpecha.pecha import Pecha
 from openpecha.pecha.serializers.pecha_db import Serializer
 
 extra_fields: Dict[str, Union[str, Dict[str, str], List[str], None]] = {
@@ -97,32 +99,88 @@ class TestSerializerIsCommentary(TestCase):
         assert self.serializer.is_commentary_pecha(metadatas)
 
 
-class TestSerializerGetRootEnTitle(TestCase):
+# class TestSerializerGetRootEnTitle(TestCase):
+#     def setUp(self):
+#         self.serializer = Serializer()
+
+#     def test_commentary_pecha(self):
+#         metadatas: list[MetadataType] = [
+#             {
+#                 "translation_of": None,
+#                 "commentary_of": "P0001",
+#                 "version_of": None,
+#                 "title": {
+#                     "en": "Illuminating the Intent Chapter 6",
+#                     "bo": "མངོན་དུ་ཕྱོགས་པར་མཉམ་བཞག་སེམས་གནས་ཏེ།",
+#                 },
+#             },
+#             {
+#                 "translation_of": None,
+#                 "commentary_of": None,
+#                 "version_of": None,
+#                 "title": {
+#                     "en": "Entering the middle Way Chapter 6",
+#                     "bo": "མངོན་དུ་ཕྱོགས་པར་མཉམ་བཞག་སེམས་གནས་ཏེ།",
+#                 },
+#             },
+#         ]
+#         assert (
+#             self.serializer.get_root_en_title(metadatas)
+#             == "Entering the middle Way Chapter 6"
+#         )
+
+
+class TestSerializer(TestCase):
     def setUp(self):
-        self.serializer = Serializer()
+        self.root_pecha = Pecha.from_path(
+            Path("tests/pecha/serializers/pecha_db/translation/data/bo/IE60BBDE8")
+        )
+        self.root_translation_pecha = Pecha.from_path(
+            Path("tests/pecha/serializers/pecha_db/translation/data/en/I62E00D78")
+        )
+        # self.commentary_pecha = Pecha.from_path("")
+        # self.commentary_translation_pecha = Pecha.from_path("")
+        self.root_pecha_metadata = {
+            "translation_of": None,
+            "commentary_of": None,
+            "version_of": None,
+            **self.root_pecha.metadata.to_dict(),
+        }
+        self.root_translation_pecha_metadata = {
+            "translation_of": "IE60BBDE8",
+            "commentary_of": None,
+            "version_of": None,
+            **self.root_translation_pecha.metadata.to_dict(),
+        }
+
+    @mock.patch(
+        "openpecha.pecha.serializers.pecha_db.translation.TranslationSerializer.serialize"
+    )
+    def test_root_pecha(self, mock_translation_serialize):
+        mock_translation_serialize.return_value = {}
+
+        pechas = [self.root_pecha]
+        metadatas = [self.root_pecha_metadata]
+        alignment_data = None
+
+        serializer = Serializer()
+        serializer.serialize(pechas, metadatas, alignment_data)
+
+        mock_translation_serialize.assert_called_once()
+        mock_translation_serialize.assert_called_with(
+            self.root_pecha, alignment_data, None
+        )
+
+    def test_root_translation_pecha(self):
+        pass
 
     def test_commentary_pecha(self):
-        metadatas: list[MetadataType] = [
-            {
-                "translation_of": None,
-                "commentary_of": "P0001",
-                "version_of": None,
-                "title": {
-                    "en": "Illuminating the Intent Chapter 6",
-                    "bo": "མངོན་དུ་ཕྱོགས་པར་མཉམ་བཞག་སེམས་གནས་ཏེ།",
-                },
-            },
-            {
-                "translation_of": None,
-                "commentary_of": None,
-                "version_of": None,
-                "title": {
-                    "en": "Entering the middle Way Chapter 6",
-                    "bo": "མངོན་དུ་ཕྱོགས་པར་མཉམ་བཞག་སེམས་གནས་ཏེ།",
-                },
-            },
-        ]
-        assert (
-            self.serializer.get_root_en_title(metadatas)
-            == "Entering the middle Way Chapter 6"
-        )
+        pass
+
+    def test_commentary_translation_pecha(self):
+        pass
+
+
+work = TestSerializer()
+work.setUp()
+work.test_root_pecha()

--- a/tests/pecha/serializers/pecha_db/serializer/test_serializer.py
+++ b/tests/pecha/serializers/pecha_db/serializer/test_serializer.py
@@ -99,37 +99,6 @@ class TestSerializerIsCommentary(TestCase):
         assert self.serializer.is_commentary_pecha(metadatas)
 
 
-# class TestSerializerGetRootEnTitle(TestCase):
-#     def setUp(self):
-#         self.serializer = Serializer()
-
-#     def test_commentary_pecha(self):
-#         metadatas: list[MetadataType] = [
-#             {
-#                 "translation_of": None,
-#                 "commentary_of": "P0001",
-#                 "version_of": None,
-#                 "title": {
-#                     "en": "Illuminating the Intent Chapter 6",
-#                     "bo": "མངོན་དུ་ཕྱོགས་པར་མཉམ་བཞག་སེམས་གནས་ཏེ།",
-#                 },
-#             },
-#             {
-#                 "translation_of": None,
-#                 "commentary_of": None,
-#                 "version_of": None,
-#                 "title": {
-#                     "en": "Entering the middle Way Chapter 6",
-#                     "bo": "མངོན་དུ་ཕྱོགས་པར་མཉམ་བཞག་སེམས་གནས་ཏེ།",
-#                 },
-#             },
-#         ]
-#         assert (
-#             self.serializer.get_root_en_title(metadatas)
-#             == "Entering the middle Way Chapter 6"
-#         )
-
-
 class TestSerializer(TestCase):
     def setUp(self):
         self.root_pecha = Pecha.from_path(
@@ -184,7 +153,7 @@ class TestSerializer(TestCase):
 
         mock_translation_serialize.assert_called_once()
         mock_translation_serialize.assert_called_with(
-            self.root_pecha, alignment_data, None
+            self.root_pecha, alignment_data, alignment_data
         )
 
     @mock.patch(

--- a/tests/pecha/serializers/pecha_db/serializer/test_serializer.py
+++ b/tests/pecha/serializers/pecha_db/serializer/test_serializer.py
@@ -138,7 +138,9 @@ class TestSerializer(TestCase):
         self.root_translation_pecha = Pecha.from_path(
             Path("tests/pecha/serializers/pecha_db/translation/data/en/I62E00D78")
         )
-        # self.commentary_pecha = Pecha.from_path("")
+        self.commentary_pecha = Pecha.from_path(
+            Path("tests/pecha/serializers/pecha_db/commentary/simple/data/bo/I6944984E")
+        )
         # self.commentary_translation_pecha = Pecha.from_path("")
         self.root_pecha_metadata = {
             "translation_of": None,
@@ -151,6 +153,12 @@ class TestSerializer(TestCase):
             "commentary_of": None,
             "version_of": None,
             **self.root_translation_pecha.metadata.to_dict(),
+        }
+        self.commentary_pecha_metadata = {
+            "translation_of": None,
+            "commentary_of": "IE60BBDE8",
+            "version_of": None,
+            **self.commentary_pecha.metadata.to_dict(),
         }
 
     @mock.patch(
@@ -191,8 +199,30 @@ class TestSerializer(TestCase):
             self.root_translation_pecha, alignment_data, self.root_pecha
         )
 
-    def test_commentary_pecha(self):
-        pass
+    @mock.patch(
+        "openpecha.pecha.serializers.pecha_db.commentary.simple_commentary.SimpleCommentarySerializer.serialize"
+    )
+    def test_commentary_pecha(self, mock_commentary_serialize):
+        mock_commentary_serialize.return_value = {}
+        pechas = [self.commentary_pecha, self.root_pecha]
+        metadatas = [self.commentary_pecha_metadata, self.root_pecha_metadata]
+        alignment_data = {
+            "source": "IE60BBDE8/layers/3635/Tibetan_Segment-039B.json",
+            "target": "I6944984E/layers/E949/Meaning_Segment-2F29.json",
+        }
+
+        serializer = Serializer()
+        serializer.serialize(pechas, metadatas, alignment_data)
+
+        mock_commentary_serialize.assert_called_once()
+        mock_commentary_serialize.assert_called_with(
+            self.commentary_pecha, alignment_data, self.root_pecha.metadata.title["EN"]
+        )
 
     def test_commentary_translation_pecha(self):
         pass
+
+
+work = TestSerializer()
+work.setUp()
+work.test_commentary_pecha()


### PR DESCRIPTION
Metadata validataion before calling Parser
- has en title
- has bo title
- if lang is zh, has zh_title (any lang)
- doest has symbols such as -,, in title

add PechaCategoryNotFound Error